### PR TITLE
time slices feature

### DIFF
--- a/src/qrm_logger/config/capture_definitions.py
+++ b/src/qrm_logger/config/capture_definitions.py
@@ -74,12 +74,21 @@ def init_capture_sets():
             crop_margin_khz = 5
         )
     )
-    #capture_sets.append(set_hf_full_wide)
+    capture_sets.append(set_hf_full_wide)
 
+    set_vhf_band = CaptureSet("VHF_band", create_vhf_specs())
+    capture_sets.append(set_vhf_band)
 
-    #set_vhf_band = CaptureSet("VHF_band", create_vhf_specs())
-    #capture_sets.append(set_vhf_band)
-
-    #set_uhf_full = CaptureSet("UHF_full", create_uhf_specs())
-    #capture_sets.append(set_uhf_full)
+    set_uhf_full = CaptureSet(
+        id = "UHF_full",
+        specs = create_step_specs(
+            start_mhz = 431,
+            end_mhz = 439,
+            step_mhz = 2,
+            suffix = " MHz",
+            crop_to_step = True,
+            crop_margin_khz= 5
+        )
+    )
+    capture_sets.append(set_uhf_full)
 

--- a/src/qrm_logger/config/visualization.py
+++ b/src/qrm_logger/config/visualization.py
@@ -70,3 +70,16 @@ grid_show_title_label = True
 # If False: Full processing including spectrum plot generation
 # Useful for high-frequency monitoring where only CSV data is needed
 skip_image_generation = False
+
+# =============================================================================
+# TIME SLICE (Across Days) SETTINGS
+# =============================================================================
+# Static settings (not user-editable in UI)
+# Limit of most recent days to include in time-slice grids (None = all days)
+timeslice_days_back = 60
+
+# Dynamic settings (stored in config.json); these are defaults used by ConfigManager
+# Hours (0–23) for which time-slice grids are generated after matching recordings
+timeslice_hours_default = [6, 12, 18]
+# Auto-generate time-slice grids after matching hourly recordings
+timeslice_autogenerate_default = False

--- a/src/qrm_logger/core/config_manager.py
+++ b/src/qrm_logger/core/config_manager.py
@@ -35,6 +35,7 @@ from qrm_logger.config.sdr_hardware import device_name, rf_gain, if_gain, sdr_sh
 from qrm_logger.config.capture_definitions import capture_sets
 from qrm_logger.sdr.sdr_rtlsdr import RTLSDR_BANDWIDTH_DEFAULT
 from qrm_logger.sdr.sdr_sdrplay import SDRPLAY_BANDWIDTH_DEFAULT
+from qrm_logger.config.visualization import timeslice_hours_default, timeslice_autogenerate_default
 
 
 class ConfigManager:
@@ -82,6 +83,9 @@ class ConfigManager:
             "sdr_shutdown_after_recording": sdr_shutdown_after_recording,
             # Per-capture-set configurations (e.g., bandwidth overrides)
             "capture_set_configurations": {},
+            # Time-slice (across days) dynamic settings
+            "timeslice_hours": timeslice_hours_default,
+            "timeslice_autogenerate": timeslice_autogenerate_default,
         }
         
         self.load_config()

--- a/src/qrm_logger/data/roi_store.py
+++ b/src/qrm_logger/data/roi_store.py
@@ -304,3 +304,6 @@ def process_rois(capture_set, runs, status: RecordingStatus, capture_params):
         except Exception as e:
             logging.error(f"Error generating ROI grid: {e}")
 
+        from src.qrm_logger.execution.data_exporter import process_timeslice_grids
+        process_timeslice_grids(roi_set_id, capture_params)
+

--- a/src/qrm_logger/execution/data_exporter.py
+++ b/src/qrm_logger/execution/data_exporter.py
@@ -268,3 +268,21 @@ def process_grids(capture_set_id, date_string):
         logging.error(f"Error generating grid: {e}")
 
 
+def process_timeslice_grids(capture_set_id, capture_params):
+    # Generate time-slice grids (across days) if enabled and this hour is configured
+    try:
+        from qrm_logger.core.config_manager import get_config_manager
+        cfg = get_config_manager()
+        if cfg.get("timeslice_autogenerate", False):
+            hours = cfg.get("timeslice_hours", []) or []
+            try:
+                anchor_hour = int(capture_params.recording_start_datetime.strftime('%H'))
+            except Exception:
+                anchor_hour = None
+            if anchor_hour is not None and anchor_hour in hours:
+                logging.info("#" * 50)
+                from qrm_logger.imaging.imge_grid_timeslice import generate_time_slice_grid
+                for plot_type in ("waterfall", "average"):
+                    generate_time_slice_grid(capture_set_id, plot_type, anchor_hour)
+    except Exception as e:
+        logging.error(f"Time-slice grid generation failed: {e}")

--- a/src/qrm_logger/execution/pipeline.py
+++ b/src/qrm_logger/execution/pipeline.py
@@ -41,6 +41,7 @@ import copy as _copy
 from qrm_logger.utils.counter import get_counter
 from qrm_logger.utils.counter import inc_counter
 
+from src.qrm_logger.execution.data_exporter import process_timeslice_grids
 
 class Pipeline:
     _instance = None
@@ -212,6 +213,7 @@ class Pipeline:
             capture_set_id = first_run.capture_set_id
             process_grids(capture_set_id, first_run.date_string)
             write_rms(capture_set_id, results,  capture_params)
+            process_timeslice_grids(capture_set_id, capture_params)
 
     def _cleanup_raw_files(self, runs):
         for run in runs:

--- a/src/qrm_logger/imaging/imge_grid_timeslice.py
+++ b/src/qrm_logger/imaging/imge_grid_timeslice.py
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2025 DO1ZL
+# This file is part of qrm-logger.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Time-slice grid utilities (across days) extracted from image_grid.
+Provides:
+- get_timeslice_grids(capture_set_id, plot_type)
+- generate_time_slice_grid(capture_set_id, plot_type, anchor_hour)
+"""
+
+import logging
+import os
+import glob
+from datetime import datetime, timedelta
+
+from PIL import Image
+
+from qrm_logger.config.output_directories import (
+    output_directory,
+    subdirectory_grids_full,
+    subdirectory_grids_resized,
+    subdirectory_metadata,
+    subdirectory_plots_resized,
+)
+from qrm_logger.config.visualization import (
+    grid_show_title_label,
+    timeslice_days_back,
+)
+from qrm_logger.data.metadata import load_plot_metadata
+from qrm_logger.utils.util import create_dirname_flat
+
+# Reuse rendering helpers from the main image_grid module
+from qrm_logger.imaging.image_grid import (
+    image_grid,
+    create_text_image,
+    create_time_note_image,
+    SPARSE_COLUMN_THRESHOLD,
+)
+
+
+def get_timeslice_grids(capture_set_id, plot_type):
+    """List available time-slice grids (across days) by hour.
+    Returns list of { hour, full, resized, last_updated }.
+    """
+    dir_full = create_dirname_flat(capture_set_id, subdirectory_grids_full)
+    dir_resized = create_dirname_flat(capture_set_id, subdirectory_grids_resized)
+
+    prefix = f"{capture_set_id}_{plot_type}_timeslice_H"
+
+    entries = {}
+
+    def _collect(dir_path, kind):
+        files = glob.glob(os.path.join(dir_path, '*.png'))
+        for f in files:
+            base = os.path.basename(f)
+            if not base.startswith(prefix):
+                continue
+            if kind == 'full' and not base.endswith('_full.png'):
+                continue
+            if kind == 'resized' and not base.endswith('_resized.png'):
+                continue
+            # Extract hour after _timeslice_H
+            try:
+                tail = base.split('_timeslice_H', 1)[1]
+                hh = tail.split('_', 1)[0]
+                hour = int(hh)
+            except Exception:
+                continue
+            rel_path = os.path.relpath(f, output_directory).replace('\\', '/')
+            e = entries.get(hour)
+            if not e:
+                e = { 'hour': hour, 'full': None, 'resized': None, 'last_updated': None }
+                entries[hour] = e
+            e[kind] = rel_path
+            try:
+                mtime = os.stat(f).st_mtime_ns
+                if not e['last_updated'] or mtime > e['last_updated']:
+                    e['last_updated'] = mtime
+            except Exception:
+                pass
+
+    _collect(dir_full, 'full')
+    _collect(dir_resized, 'resized')
+
+    result = []
+    for hour in sorted(entries.keys()):
+        e = entries[hour]
+        for k in ('full', 'resized'):
+            if e[k]:
+                e[k] = f"{e[k]}?t={e['last_updated']}"
+        result.append(e)
+    return result
+
+
+def generate_time_slice_grid(capture_set_id, plot_type, anchor_hour):
+    """Generate a grid comparing the same hour across multiple days.
+
+    Saves two files in grids_full/grids_resized with names:
+      <set>_<plot_type>_timeslice_H{HH}_full.png and _resized.png
+    """
+    # Once-per-hour guard: if the resized output exists and was written this wall-clock hour, skip
+    try:
+        directory_grids_full = create_dirname_flat(capture_set_id, subdirectory_grids_full)
+        out_full = directory_grids_full + capture_set_id + f"_{plot_type}_timeslice_H{int(anchor_hour):02d}_full.png"
+        now = datetime.now()
+        hour_start = now.replace(minute=0, second=0, microsecond=0)
+        hour_end = hour_start + timedelta(hours=1)
+        if os.path.exists(out_full):
+            mtime = datetime.fromtimestamp(os.stat(out_full).st_mtime)
+            if hour_start <= mtime < hour_end:
+                logging.info(f"Time-slice skip (once-per-hour): {capture_set_id}/{plot_type} H{int(anchor_hour):02d} already rendered this hour")
+                return
+    except Exception:
+        pass
+
+    # Discover day folders (YYYY-MM-DD) under metadata
+    meta_root = os.path.join(output_directory, capture_set_id, subdirectory_metadata)
+    if not os.path.exists(meta_root):
+        logging.info(f"No metadata directory for set {capture_set_id}")
+        return
+    days = [d for d in os.listdir(meta_root) if os.path.isdir(os.path.join(meta_root, d))]
+    # sort desc (newest first)
+    days.sort(reverse=True)
+    if timeslice_days_back and isinstance(timeslice_days_back, int) and timeslice_days_back > 0:
+        days = days[:timeslice_days_back]
+
+    # For each day, select the first image recorded in the target hour
+    per_day = []  # list of { day, time, files_by_spec }
+    union_specs = []
+    spec_seen = set()
+
+    anchor_hour_int = int(anchor_hour)
+
+    for day in days:
+        md = load_plot_metadata(capture_set_id, day, plot_type) or {}
+        if not md:
+            continue  # skip day entirely
+        # collect candidates exactly matching the anchor hour
+        candidates = []  # list of (minute, time_string)
+        for filename, meta in md.items():
+            ts = meta.get('time_string') or '00:00'
+            try:
+                h, m = ts.split(':', 1)
+                if int(h) == anchor_hour_int:
+                    candidates.append((int(m), ts))
+            except Exception:
+                continue
+        if not candidates:
+            continue  # skip day entirely
+        # pick earliest minute within the hour
+        candidates.sort(key=lambda x: x[0])
+        chosen_time = candidates[0][1]
+        files = {}
+        for filename, meta in md.items():
+            if meta.get('time_string') == chosen_time:
+                spec_id = meta.get('capture_id')
+                if spec_id and spec_id not in files:
+                    files[spec_id] = filename
+                    if spec_id not in spec_seen:
+                        spec_seen.add(spec_id)
+                        union_specs.append(spec_id)
+        per_day.append({ 'day': day, 'time': chosen_time, 'files': files })
+
+    if not union_specs:
+        logging.info("Time-slice: no images found to compose")
+        return
+
+    # pick a sample image size from first available plot
+    sample_w, sample_h = 512, 512
+    for row in per_day:
+        if row['files']:
+            any_spec = next(iter(row['files'].keys()))
+            img_path = os.path.join(output_directory, capture_set_id, subdirectory_plots_resized, row['day'], row['files'][any_spec])
+            try:
+                with Image.open(img_path) as im:
+                    sample_w, sample_h = im.size
+                    break
+            except Exception:
+                pass
+
+    # Determine column widths using the actual image width (ensures time column images are sized to full cell height)
+    row_count = len(per_day) + 1
+    col_count_total = len(union_specs) + 1
+    data_columns = col_count_total - 1
+    def compute_column_widths(image_width):
+        if data_columns <= SPARSE_COLUMN_THRESHOLD:
+            time_w = int(image_width * 0.6)
+            data_w = image_width
+            return [time_w] + [data_w] * data_columns
+        else:
+            return None
+    col_widths = compute_column_widths(sample_w)
+    time_image_size = (col_widths[0], sample_h) if col_widths else (sample_w, sample_h)
+    data_image_size = (col_widths[1], sample_h) if col_widths else (sample_w, sample_h)
+
+    # Build image list: header + rows (use sizes aligned with column widths to avoid black padding)
+    images = []
+    header_text = f"{int(anchor_hour):02d}:00" if grid_show_title_label else ""
+    images.append(create_text_image(header_text, 60, time_image_size, 40))
+    for label in union_specs:
+        images.append(create_text_image(label, 60, data_image_size, 70))
+
+    # Use smaller fonts for the time-slice row first column (date/time)
+    # Scale relative to image height and clamp to conservative bounds to avoid overflow
+    ts_time_font = max(40, min(80, int(sample_h * 0.12)))
+    ts_note_font = max(28, min(55, int(sample_h * 0.08)))
+    for row in per_day:
+        time_label = row['time'] or ''
+        images.append(create_time_note_image(row['day'], time_label, time_image_size, ts_time_font, ts_note_font))
+        for spec in union_specs:
+            if spec in row['files']:
+                images.append(os.path.join(output_directory, capture_set_id, subdirectory_plots_resized, row['day'], row['files'][spec]))
+            else:
+                # Fill missing spec cells with a plain blank tile (no text)
+                images.append(Image.new(mode="RGB", size=data_image_size, color='grey'))
+
+    grid_img = image_grid(images, rows=row_count, cols=col_count_total, w=sample_w, h=sample_h, col_widths=col_widths)
+
+    # Save
+    directory_grids_full = create_dirname_flat(capture_set_id, subdirectory_grids_full)
+    filename_full = directory_grids_full + capture_set_id + f"_{plot_type}_timeslice_H{int(anchor_hour):02d}_full.png"
+    logging.info("save time-slice grid file "+str(grid_img.size)+ ": "+ filename_full)
+    grid_img.save(filename_full)
+
+    directory_grids_resized = create_dirname_flat(capture_set_id, subdirectory_grids_resized)
+    filename_resized = directory_grids_resized + capture_set_id + f"_{plot_type}_timeslice_H{int(anchor_hour):02d}_resized.png"
+    grid_img.thumbnail((2048, 2048), Image.Resampling.LANCZOS)
+    logging.info("save time-slice resized grid file "+str(grid_img.size)+ ": "+ filename_resized)
+    grid_img.save(filename_resized)
+    grid_img.close()
+

--- a/src/qrm_logger/utils/util.py
+++ b/src/qrm_logger/utils/util.py
@@ -30,7 +30,7 @@ from qrm_logger.core.objects import CaptureRun, CaptureSpec, FreqRange
 
 from qrm_logger.config.output_directories import output_directory
 
-VERSION = "0.1.3"
+VERSION = "0.1.4"
 
 
 def create_filename(run: CaptureRun, prefix, file_extension):
@@ -123,8 +123,9 @@ def create_vhf_specs():
 
 def create_uhf_specs():
     return [
-        create_simple_spec( 0, id = "433 MHz", center_khz = 433_000, span_khz = 2_000),
-        create_simple_spec(1, id="439 MHz", center_khz=439_000, span_khz=2_000)
+        create_simple_spec( 0, id = "432 MHz", center_khz = 432_000, span_khz = 2_000),
+        create_simple_spec(1, id="437 MHz", center_khz=437_000, span_khz=2_000),
+        #create_simple_spec(2, id="439 MHz", center_khz=439_000, span_khz=2_000)
     ]
 
 def create_band_specs(band_ids, suffix):

--- a/ui/components/config-modal.html
+++ b/ui/components/config-modal.html
@@ -49,6 +49,11 @@
                             ROIs
                         </a>
                     </li>
+                    <li :class="{ 'is-active': $store.config.activeTab === 'timeslices' }">
+                        <a @click="$store.config.setActiveTab('timeslices')">
+                            Time Slices
+                        </a>
+                    </li>
                     <li :class="{ 'is-active': $store.config.activeTab === 'about' }">
                         <a @click="$store.config.setActiveTab('about')">
                             About
@@ -349,6 +354,28 @@
                                 <span x-text="$store.app.status.recording ? 'Recording in Progress...' : 'Start Calibration Recording'"></span>
                             </button>
                         </div>
+                    </div>
+                </div>
+
+                <!-- Time Slices Tab -->
+                <div x-show="$store.config.activeTab === 'timeslices'" x-cloak>
+                    <h3 class="title is-5" style="margin-bottom: 0.5rem;">Time Slices</h3>
+                    <p class="help" style="margin-bottom: 0.75rem; color: #a5a5a5;">
+                        Generates across‑day grids for the selected hours (per plot type). After a recording for one of these hours completes,
+                        the grid for that hour is rebuilt (at most once per hour). For each day, the first recording in that hour is used.
+                    </p>
+                    <div class="field" style="margin-bottom: 1rem;">
+                        <label class="checkbox">
+                            <input type="checkbox" x-model="$store.config.form.timeslice_autogenerate">
+                            Enable processing
+                        </label>
+                    </div>
+                    <div class="field">
+                        <label class="label">Hours (0–23, comma-separated)</label>
+                        <div class="control">
+                            <input class="input" type="text" x-model="$store.config.form.timeslice_hours_text" placeholder="e.g. 6, 12, 18">
+                        </div>
+                        <p class="help">Specify hours of the day to track. Example: 6, 12, 18 → 06:00, 12:00, 18:00.</p>
                     </div>
                 </div>
 

--- a/ui/components/grid-view.html
+++ b/ui/components/grid-view.html
@@ -1,8 +1,12 @@
 <!-- Grid View Component -->
-<div x-data="{ async getGrids() { return Alpine.store('grid').getData() } }" x-init="getGrids()" x-cloak>
-  <!-- Controls Row: Plot Type Toggle (Waterfall/Average) -->
+<div x-data="{ async refresh() { return Alpine.store('grid').getData() } }" x-init="refresh()" x-cloak>
+  <!-- Controls Row: Plot Type + Tab Toggle -->
   <div class="columns is-mobile" style="margin-bottom: 10px">
-    <div class="column" style="padding-bottom: 5px">
+    <div class="column" style="padding-bottom: 5px; display:flex; gap:12px; align-items:center; flex-wrap:wrap; flex-direction: column; align-items: flex-start;">
+      <div class="buttons has-addons" x-show="$store.grid.isTimeSliceEnabled()" x-cloak>
+        <button class="button is-small" :class="$store.grid.gridTab === 'daily' ? 'is-primary' : 'is-dark'" @click="$store.grid.setGridTab('daily')">Daily</button>
+        <button class="button is-small" :class="$store.grid.gridTab === 'timeslices' ? 'is-primary' : 'is-dark'" @click="$store.grid.setGridTab('timeslices')">Time Slices</button>
+      </div>
       <div class="buttons has-addons">
         <button
           class="button is-small"
@@ -24,8 +28,46 @@
     </div>
   </div>
 
-  <!-- Outer loop over days -->
-  <template x-for="(day, dIndex) in ($store.grid.getVisibleGroupedData() || [])" :key="day.date">
+  <!-- Time Slices view -->
+  <template x-if="$store.grid.gridTab === 'timeslices'">
+    <div>
+      <template x-for="ts in ($store.grid.getVisibleTimeSlices() || [])" :key="ts.hour">
+        <div style="margin-bottom: 30px;">
+          <!-- Header row: hour badge (left) + shared scale controls (right) -->
+          <div class="is-size-6 has-text-weight-semibold" style="margin-bottom: 0.5rem; display: flex; align-items: center; justify-content: space-between; gap: 0.5rem;">
+            <div>
+              <span class="tag is-large"
+                    style="background: transparent;
+                           color: darkorange;
+                           border: 1px dashed darkorange;
+                           padding: 0.75em 1.25em;
+                           font-weight: 700;
+                           font-size: 1.15rem;
+                           font-family: 'Courier New', monospace;">
+                <span x-text="String(ts.hour).padStart(2,'0')"></span>:00
+              </span>
+            </div>
+            <div class="is-flex is-align-items-center" style="gap: 0.4rem;">
+              <button class="button is-small is-dark" title="Decrease image width" :disabled="$store.grid.imageScalePercent <= 10" @click="$store.grid.decImageScale()">−</button>
+              <button class="button is-small is-dark" title="Increase image width" :disabled="$store.grid.imageScalePercent >= 100" @click="$store.grid.incImageScale()">+</button>
+              <button class="button is-small is-dark" title="Reset to 100%" :disabled="$store.grid.imageScalePercent === 100" @click="$store.grid.resetImageScale()">100%</button>
+            </div>
+          </div>
+          <div>
+            <img :src="$store.grid.getTimesliceImage(ts, true)"
+                 @click="$store.grid.openZoomTimeslice(ts)"
+                 :style="'cursor: pointer; height: auto; max-width: 100%; display: block; margin: 0 auto; width: ' + $store.grid.imageScalePercent + '%;'" />
+          </div>
+        </div>
+      </template>
+    </div>
+  </template>
+
+  <!-- Daily view -->
+  <template x-if="$store.grid.gridTab === 'daily'">
+    <div>
+      <!-- Outer loop over days -->
+      <template x-for="(day, dIndex) in ($store.grid.getVisibleGroupedData() || [])" :key="day.date">
     <div>
       <div style="margin-bottom: 30px">
         <span style="display: inline-block;
@@ -135,8 +177,11 @@
       </template>
     </div>
   </template>
-  <!-- Summary (render only when available) at bottom -->
-  <template x-if="$store.grid.getSummary()">
+    </div>
+  </template>
+
+  <!-- Summary (render only when available) at bottom; only for Daily view -->
+  <template x-if="$store.grid.gridTab === 'daily' && $store.grid.getSummary()">
     <div class="has-text-grey is-size-7" style="margin: 0.75rem 0 20px 0;">
       <span style="color: #b5b5b5;">grid summary:</span>
       <span style="margin-left: 0.5rem;">days covered: <span x-text="$store.grid.getSummary().days"></span></span>


### PR DESCRIPTION
1) implemented time slices feature
2) added VHF and UHF capture sets

**Usage:**

Configuring Time Slices via the Config modal

•  Open the Config modal → Time Slices tab.
•  Enable processing: check “Enable processing”. This turns on time slice generation 
•  Select hours: enter a comma‑separated list of hours (0–23) 
•  Save: click Save to apply. Time slice grids are (re)built after the next recording whose start hour matches a configured hour.

Grid view behavior
•  When processing is enabled, a small toggle appears: “Daily” and “Time Slices.” Switch to “Time Slices” to see one card per configured hour; if disabled, this toggle is hidden.

Closes : #2 
