### PR TITLE
timezone fix

### DIFF
--- a/src/qrm_logger/scheduling/scheduler.py
+++ b/src/qrm_logger/scheduling/scheduler.py
@@ -126,9 +126,9 @@ class Scheduler:
                 return None
             next_run = min(jobs, key=lambda j: j.next_run_time).next_run_time
             if next_run:
-                # Convert to local time and format as string for UI
+                # Convert to local time and format as ISO 8601 with timezone for UI
                 local_dt = next_run.astimezone()
-                return local_dt.strftime('%Y-%m-%d %H:%M:%S')
+                return local_dt.isoformat()
             return None
         except Exception as e:
             logging.error(f"Error getting next scheduled time: {e}")

--- a/ui/stores/app-store.js
+++ b/ui/stores/app-store.js
@@ -282,38 +282,50 @@ document.addEventListener('alpine:init', () => {
 
     formatTimeOnly(dateTimeString) {
       if (!dateTimeString) return '';
-      // Extract time from 'YYYY-MM-DD HH:MM:SS' format
-      const parts = dateTimeString.split(' ');
-      if (parts.length >= 2) {
-        const timeParts = parts[1].split(':');
-        if (timeParts.length >= 2) {
-          return `${timeParts[0]}:${timeParts[1]}`; // Return HH:MM format
+      // Parse ISO 8601 format (e.g., '2025-11-25T23:30:00+01:00') or legacy format
+      try {
+        const date = new Date(dateTimeString);
+        if (!isNaN(date)) {
+          const hours = String(date.getHours()).padStart(2, '0');
+          const minutes = String(date.getMinutes()).padStart(2, '0');
+          return `${hours}:${minutes}`;
         }
-        return parts[1]; // Return as-is if time format is unexpected
+      } catch (e) {
+        // Fallback for unexpected formats
       }
-      return dateTimeString; // Return as-is if format is unexpected
+      return dateTimeString;
     },
 
     formatDateOnly(dateTimeString) {
       if (!dateTimeString) return '';
-      const parts = dateTimeString.split(' ');
-      if (parts.length >= 1) {
-        return parts[0]; // YYYY-MM-DD
+      // Parse ISO 8601 format or legacy format
+      try {
+        const date = new Date(dateTimeString);
+        if (!isNaN(date)) {
+          const yyyy = date.getFullYear();
+          const mm = String(date.getMonth() + 1).padStart(2, '0');
+          const dd = String(date.getDate()).padStart(2, '0');
+          return `${yyyy}-${mm}-${dd}`;
+        }
+      } catch (e) {
+        // Fallback for unexpected formats
       }
       return '';
     },
 
     isSameDay(dateTimeString) {
       if (!dateTimeString) return true;
-      const parts = dateTimeString.split(' ');
-      if (parts.length >= 1) {
-        const nextDateStr = parts[0]; // YYYY-MM-DD
+      // Parse ISO 8601 format or legacy format
+      try {
+        const nextDate = new Date(dateTimeString);
         const now = new Date();
-        const yyyy = now.getFullYear();
-        const mm = String(now.getMonth() + 1).padStart(2, '0');
-        const dd = String(now.getDate()).padStart(2, '0');
-        const todayStr = `${yyyy}-${mm}-${dd}`;
-        return nextDateStr === todayStr;
+        if (!isNaN(nextDate)) {
+          return nextDate.getFullYear() === now.getFullYear() &&
+                 nextDate.getMonth() === now.getMonth() &&
+                 nextDate.getDate() === now.getDate();
+        }
+      } catch (e) {
+        // Fallback
       }
       return true;
     },


### PR DESCRIPTION
Issue Resolution

Root Cause: The server was sending scheduled times as plain strings without timezone information (e.g., "2025-11-25 15:30:00"). When the client parsed this string, it interpreted it as local client time rather than server time, causing incorrect countdown calculations when server and client were in different timezones.

Solution Implemented:
1. Backend (scheduler.py): Changed timestamp format from strftime('%Y-%m-%d %H:%M:%S') to isoformat(), which sends timezone-aware ISO 8601 timestamps (e.g., "2025-11-25T15:30:00+01:00")
2. Frontend (app-store.js): Updated formatTimeOnly(), formatDateOnly(), and isSameDay() functions to properly parse ISO 8601 format while maintaining backward compatibility

The countdown timer now displays accurate times regardless of timezone differences between server and client.


closes #4