### PR TITLE
Fix error handling when a recording fails

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -23,6 +23,42 @@ built-in source types: file rtl rtl_tcp uhd miri hackrf bladerf airspy airspyhf 
 This never happens on Raspberry Pi Linux. Not sure about the reason. You can try disabling `sdr_shutdown_after_recording` (keep SDR running between recordings) and see if it helps.
 
 
+#### SDR disconnected during recording
+
+If the SDR is unplugged or drops off the USB bus while recording, the recording
+first stalls and the application may then exit:
+
+```
+2026-08-11 13:55:55,905 - root - INFO - Record 30m | center_frequency=10100 kHz | span=2400 kHz | duration=2.0 s
+cb transfer status: 4, canceling...
+cb transfer status: 5, canceling...
+rtlsdr_read_async returned with -5
+```
+
+The device stops delivering samples without reporting an error to the application,
+so the running capture never finishes on its own. A timeout ends it after the
+recording duration plus `capture_timeout_margin_sec` (see `config-static.toml`),
+logs `SDR delivered no data for ... - device stalled or disconnected`, and aborts
+the remaining captures of that run.
+
+Shutting the SDR down afterwards can then terminate the process without any
+further log output. The cause is in the RTL-SDR driver: after the USB device is
+gone, librtlsdr still cleans up its transfer buffers and crashes. This cannot be
+caught by the application, since it happens in native code, not in Python.
+
+I observed this with RTLSDR on Windows. SDRplay uses a separate API service
+process for the USB communication, so it is likely to behave differently there.
+
+The SDR cannot be reconnected without restarting the application. On Raspberry Pi
+the systemd service (`Restart=always`) starts it again automatically, so the next
+scheduled recording runs as usual. Windows has no systemd equivalent, but a small
+batch file that starts `main.py` in an endless loop does the same job: the crash
+only ends the process, so the loop starts it again.
+
+If this happens without anyone touching the hardware, suspect USB power: a weak
+supply or a long/thin cable can make the dongle drop off the bus under load.
+
+
 #### Application crashes with OutOfMemory Error
 
 Each frequency slice is recorded in memory and written to disk after recording is completed. 

--- a/src/qrm_logger/config/configuration_defaults.py
+++ b/src/qrm_logger/config/configuration_defaults.py
@@ -62,6 +62,10 @@ frame_rate_default = 25
 # Recommended values: RTLSDR 0.5, SDRplay 2
 frequency_change_delay_sec = 0.5
 
+# Extra time granted to a capture run before the SDR is considered stalled (seconds)
+# Catches a device that stops delivering samples, e.g. after being unplugged
+capture_timeout_margin_sec = 10
+
 [recording.fft]
 # FFT size for spectrum analysis (must be power of 2)
 # Higher values = better frequency resolution but slower processing

--- a/src/qrm_logger/config/recording_params.py
+++ b/src/qrm_logger/config/recording_params.py
@@ -37,6 +37,12 @@ frame_rate_default = _toml["recording"]["frame_rate_default"]
 # Recommended values: RTLSDR 0.5, SDRplay 2
 frequency_change_delay_sec = _toml["recording"]["frequency_change_delay_sec"]
 
+# Extra time granted to a capture run on top of its recording duration before the
+# SDR is considered stalled. A device that disappears mid-recording (USB unplug,
+# driver error) stops delivering samples without raising anything, so this timeout
+# is the only way the recording loop notices.
+capture_timeout_margin_sec = _toml["recording"].get("capture_timeout_margin_sec", 10)
+
 # =============================================================================
 # FFT CONFIGURATION
 # =============================================================================

--- a/src/qrm_logger/execution/pipeline.py
+++ b/src/qrm_logger/execution/pipeline.py
@@ -90,7 +90,9 @@ class Pipeline:
         self.recording = True
         self.record_start_time = time.time()
         self.recording_status = RecordingStatus()
+        # Drop the error of the previous run, so the UI only shows current ones
         self.error_text = None
+        get_recorder().clear_error()
 
         # Populate capture params
         counter = inc_counter()
@@ -144,14 +146,16 @@ class Pipeline:
             if not success:
                 return
 
-            if status.cancel_requested:
-                logging.info("Recording cancelled")
+            sets_recorded = []
+            try:
+                if status.cancel_requested:
+                    logging.info("Recording cancelled")
+                    return
+
+                sets_recorded, cancelled = get_recorder().execute_recordings(status, sets_to_record, capture_params)
+            finally:
+                # Always release the SDR, also when recording raised
                 get_recorder().on_record_end()
-                return
-
-            sets_recorded, cancelled = get_recorder().execute_recordings(status, sets_to_record, capture_params)
-
-            get_recorder().on_record_end()
 
             if cancelled or status.cancel_requested:
                 logging.info("Processing cancelled")
@@ -169,6 +173,7 @@ class Pipeline:
             logging.error(f"Pipeline failed during execution: {str(e)}")
             logging.error(traceback.format_exc())
             status.operation = "ERROR"
+            self.error_text = str(e) or type(e).__name__
             raise
         finally:
             clear_all_collected_log_texts()

--- a/src/qrm_logger/recorder/recorder.py
+++ b/src/qrm_logger/recorder/recorder.py
@@ -56,21 +56,37 @@ class Recorder:
     def get_error_text(self):
         return self.error_text
 
+    def clear_error(self):
+        self.error_text = None
+
     def on_record_start(self):
+        # Flagged as busy right away, so that the SDR cannot be shut down while starting up
         self.recording = True
-        if not self.receiver:
-            success = self.create_receiver()
-            if not success:
-                return False
-        return self.start_receiver()
+        started = False
+        try:
+            if not self.receiver:
+                if not self.create_receiver():
+                    return False
+            started = self.start_receiver()
+            return started
+        finally:
+            if not started:
+                # Startup failed: do not leave the recorder flagged as busy
+                self.recording = False
 
     def on_record_end(self):
         logging.info("Recording session complete")
-        self.stop_receiver()
-        if get_config_manager().get("sdr_shutdown_after_recording", True):
-            self.disconnect_receiver()
-
-        self.recording = False
+        try:
+            self.stop_receiver()
+            if get_config_manager().get("sdr_shutdown_after_recording", True):
+                self.disconnect_receiver()
+        except Exception as e:
+            # Do not mask the error that ended the recording; drop the receiver
+            # so the next run creates a fresh one instead of reusing a broken flowgraph
+            logging.error(f"Failed to shut down SDR cleanly: {e}")
+            self.receiver = None
+        finally:
+            self.recording = False
 
 
     def create_receiver(self):
@@ -95,7 +111,6 @@ class Recorder:
         except Exception as ex:
             logging.error("could not start SDR: "+str(ex))
             self.error_text = str(ex)
-            self.recording = False
             self.receiver = None
             raise
         return success
@@ -139,6 +154,7 @@ class Recorder:
             self.receiver.start()
         except Exception as e:
             logging.error(f"Failed to start SDR: {e}")
+            self.error_text = "Failed to start SDR: " + (str(e) or type(e).__name__)
             return False
         return True
 

--- a/src/qrm_logger/recorder/recorder.py
+++ b/src/qrm_logger/recorder/recorder.py
@@ -16,15 +16,26 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import logging
+import threading
 import time
 
 from gnuradio import gr
 
 from qrm_logger.core.config_manager import get_config_manager
-from qrm_logger.config.recording_params import frequency_change_delay_sec, frame_rate_default
+from qrm_logger.config.recording_params import (
+    frequency_change_delay_sec,
+    frame_rate_default,
+    capture_timeout_margin_sec,
+)
 from qrm_logger.config.sdr_hardware import device_name
 from qrm_logger.core.objects import RecordingStatus, CaptureRun
 from qrm_logger.recorder.fft_receiver import fft_receiver
+
+
+# Safety limit for the GNU Radio flowgraph shutdown. Stopping a device that is
+# already gone can block in wait(), which would hang the recording thread in the
+# very situation the teardown is meant to recover from.
+sdr_stop_timeout_sec = 15
 
 
 class Recorder:
@@ -162,8 +173,18 @@ class Recorder:
 
     def _stop_receiver_internal(self):
         logging.info(f"Stopping SDR ({device_name})...")
-        self.receiver.stop()
-        self.receiver.wait()
+        receiver = self.receiver
+
+        def _stop_and_wait():
+            receiver.stop()
+            receiver.wait()
+
+        stopper = threading.Thread(target=_stop_and_wait, name="sdr-stop", daemon=True)
+        stopper.start()
+        stopper.join(sdr_stop_timeout_sec)
+        if stopper.is_alive():
+            # Let on_record_end() drop the receiver, so the next run builds a fresh one
+            raise RuntimeError(f"SDR did not stop within {sdr_stop_timeout_sec} s")
 
     def _disconnect_internal(self):
         logging.info(f"Shutting down SDR ({device_name})...")
@@ -248,29 +269,61 @@ class Recorder:
         """
         status.jobs_total_number = len(runs)
         number = 0
-        for run in runs:
-            if self._check_if_stopped():
-                break
-
-            self.receiver.set_frequency(run.freq)
-            self.receiver.set_sample_rate(run.span)
-
-            time.sleep(frequency_change_delay_sec)
-
-            self.receiver.fft_record_sink.start_record(run)
-
-            while self.receiver.fft_record_sink.is_recording:
+        try:
+            for run in runs:
                 if self._check_if_stopped():
                     break
-                time.sleep(0.1)
 
-            number = number + 1
-            status.current_job_number = number
+                self.receiver.set_frequency(run.freq)
+                self.receiver.set_sample_rate(run.span)
 
-        cancelled = self.stop_requested
-        # Reset the flag for future batches
-        self.stop_requested = False
-        return not cancelled
+                time.sleep(frequency_change_delay_sec)
+
+                self.receiver.fft_record_sink.start_record(run)
+                self._wait_for_run(run)
+
+                number = number + 1
+                status.current_job_number = number
+
+            cancelled = self.stop_requested
+            return not cancelled
+        finally:
+            # Reset the flag for future batches, also when a run raised
+            self.stop_requested = False
+
+    def _wait_for_run(self, run):
+        """Wait for a capture run to finish, or raise if the SDR goes silent.
+
+        The sink only leaves the recording state while it receives samples, so a
+        device that disappears mid-run (USB unplug, driver error) never ends the
+        run and never raises: librtlsdr reports the failure on its own thread and
+        the source block simply stops producing. The deadline is what turns that
+        silence into an error.
+        """
+        deadline = time.monotonic() + run.rec_time_ms / 1000.0 + capture_timeout_margin_sec
+
+        while self.receiver.fft_record_sink.is_recording:
+            if self._check_if_stopped():
+                return
+            if time.monotonic() > deadline:
+                self._abort_stalled_run(run)
+            time.sleep(0.1)
+
+    def _abort_stalled_run(self, run):
+        message = (
+            f"SDR delivered no data for {run.id} within "
+            f"{round(run.rec_time_ms / 1000.0 + capture_timeout_margin_sec, 1)} s "
+            f"- device stalled or disconnected"
+        )
+        logging.error(message)
+        self.error_text = message
+        try:
+            # Release the sink, so it does not stay armed for the next run
+            self.receiver.fft_record_sink.stop_now()
+        except Exception as e:
+            logging.error(f"failed to stop sink after stall: {e}")
+        # Abort the batch: the remaining runs would hit the same dead device
+        raise RuntimeError(message)
 
 
     def _check_if_stopped(self):

--- a/src/qrm_logger/web/web_routes.py
+++ b/src/qrm_logger/web/web_routes.py
@@ -75,7 +75,8 @@ def status():
             record_progress = str(stat.operation) + " [" + str(stat.current_job_number) + "/" + str(
                 stat.jobs_total_number) + "]"
 
-    error_text = get_recorder().get_error_text()
+    # Pipeline errors first (most recent), SDR errors as fallback
+    error_text = p.get_error_text() or get_recorder().get_error_text()
 
     sch = get_scheduler()
     next_scheduled = sch.get_next_scheduled_time()


### PR DESCRIPTION
Fixes #13 

Makes a failing recording end in a defined state, instead of leaving the SDR
claimed, the error invisible in the UI, or the application stuck.

- Release the SDR in a `finally`, so an exception during recording no longer
  leaves the flowgraph running and the device claimed. `on_record_end()` is now
  safe to call from a `finally` and cannot mask the original error.
- Reset the recording flag when SDR startup fails, which permanently blocked
  `/sdr-control` before.
- Surface pipeline and SDR errors in `/status`. `Pipeline.error_text` was never
  assigned, so errors only ever appeared in the log.
- Abort a capture run when the SDR stops delivering samples. A device that is
  unplugged or drops off the USB bus reports nothing to the application, so the
  recording loop waited forever. The new `capture_timeout_margin_sec` setting
  controls the grace period.
- Bound the flowgraph shutdown with a timeout, so stopping a device that is
  already gone cannot block the recording thread as well.

Not fixed: after an RTL-SDR is disconnected, the process can still die while the
device is shut down. That happens inside librtlsdr and cannot be caught from
Python, so it is documented in `troubleshooting.md` together with the restart
options.